### PR TITLE
Fix viewer rendering bugs and add build automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# dekweb — Makefile
+
+# Tools
+NODE = node
+WEAVE = weave
+PDFTEX = pdftex
+NPM = npm
+
+# Directories
+SRC_DIR = src
+WEB_DIR = web-sources
+OUT_DIR = output
+VIEWER_DIR = viewer
+
+# Files
+WEBS = $(wildcard $(WEB_DIR)/*.web)
+HTMLS = $(patsubst $(WEB_DIR)/%.web,$(OUT_DIR)/%.html,$(WEBS))
+PDFS = $(patsubst $(WEB_DIR)/%.web,%.pdf,$(WEBS))
+
+.PHONY: all html pdf clean test setup
+
+# Default target
+all: html pdf
+
+# Generate HTML viewer files
+html: $(HTMLS)
+
+$(OUT_DIR)/%.html: $(WEB_DIR)/%.web $(SRC_DIR)/*.js $(VIEWER_DIR)/*
+	@mkdir -p $(OUT_DIR)
+	$(NODE) $(SRC_DIR)/build.js $*
+
+# Generate PDF reference files
+pdf: $(PDFS)
+
+%.pdf: $(WEB_DIR)/%.web
+	$(WEAVE) $<
+	$(PDFTEX) $*.tex
+
+# Run tests
+test:
+	$(NPM) test
+
+# Initial setup: install dependencies and fetch WEB sources
+setup:
+	$(NPM) install
+	$(NPM) run fetch
+
+# Cleanup build artifacts
+clean:
+	rm -rf $(OUT_DIR)
+	rm -f *.pdf *.tex *.log *.idx *.scn CONTENTS.tex

--- a/src/build.js
+++ b/src/build.js
@@ -44,9 +44,18 @@ function renderCode(raw, chunkDefs) {
   // Strip other WEB control codes that don't translate to code
   processed = processed
     .replace(/@[@/|#+;!]/g, m => m === '@@' ? '@' : '')
-    .replace(/@=[^@]*@>/g, m => m.slice(2, -2)) // @=verbatim@> → verbatim
-    .replace(/@'[^']*'/g, m => m)                // @'x' character literal — keep
-    .replace(/@"[0-9a-fA-F]*/g, m => m);         // @"hex — keep
+    .replace(/@t[\s\S]*?@>/g, '')                  // @t... @> format control
+    .replace(/@h/g, '')                            // @h (header)
+    .replace(/@&/g, '')                            // @& (concatenate)
+    .replace(/@\+/g, '')                           // @+ (indent)
+    .replace(/@;/g, '')                            // @; (semicolon)
+    .replace(/@\./g, '')                           // @. (typewriter)
+    .replace(/@:/g, '')                            // @: (index)
+    .replace(/@\^/g, '')                           // @^ (index)
+    .replace(/@=[^@]*@>/g, m => m.slice(2, -2))   // @=verbatim@> → verbatim
+    .replace(/@'[^']*'/g, m => m)                  // @'x' character literal
+    .replace(/@"0-9a-fA-F]*/g, m => m);           // @"hex
+
 
   // Prism highlight
   let highlighted;
@@ -72,21 +81,35 @@ function renderCode(raw, chunkDefs) {
  * Render a single section as an HTML string.
  */
 function renderSection(sec, chunkDefs) {
-  const { number, starred, title, tex, defs, code, chunkName } = sec;
+  const { number, starred, partNumber, title, tex, defs, code, chunkName } = sec;
 
   const id = `s${number}`;
   const cls = starred ? 'section starred' : 'section';
 
-  const numHtml = `<div class="section-num"><a href="#${id}">${number}</a></div>`;
+  const numHtml = `<div class="section-num"><a href="#${id}">§${number}</a></div>`;
 
   let bodyHtml = '';
 
   if (starred && title) {
-    bodyHtml += `<div class="section-title">${escapeHtml(title)}</div>\n`;
+    const partLabel = partNumber != null
+      ? `<span class="part-label">Part ${partNumber}</span>`
+      : '';
+    bodyHtml += `<div class="section-title">${partLabel}${escapeHtml(title)}.</div>\n`;
   }
 
-  if (tex) {
-    bodyHtml += `<div class="tex-prose">${texToHtml(tex)}</div>\n`;
+  if (tex || (!starred && !defs.length && !code.trim())) {
+    // Render prose. For unstarred sections we prefix a bold marker like the PDF.
+    const proseHtml = texToHtml(tex);
+    if (!starred) {
+      // Insert bold "N." marker at the start of the first paragraph
+      const withMarker = proseHtml.replace(
+        /^<p>/,
+        `<p><span class="section-marker">${number}.</span>`
+      );
+      bodyHtml += `<div class="tex-prose">${withMarker}</div>\n`;
+    } else {
+      bodyHtml += `<div class="tex-prose">${proseHtml}</div>\n`;
+    }
   }
 
   if (defs.length) {
@@ -132,7 +155,10 @@ function buildToc(sections) {
     .filter(s => s.starred)
     .map(s => {
       const label = s.title ? escapeHtml(s.title) : `Section ${s.number}`;
-      return `<li><a href="#s${s.number}"><span class="sec-num">§${s.number}</span>${label}</a></li>`;
+      const lead = s.partNumber != null
+        ? `<span class="part-num">Part ${s.partNumber}</span>`
+        : `<span class="sec-num">§${s.number}</span>`;
+      return `<li><a href="#s${s.number}">${lead}<span class="toc-label">${label}</span></a></li>`;
     });
   return `<ul id="toc">\n${items.join('\n')}\n</ul>`;
 }
@@ -178,8 +204,8 @@ ${prismCss}
 </nav>
 <main id="main">
   <header id="doc-header">
-    <h1>${escapeHtml(docTitle)}</h1>
-    <div class="subtitle">Knuth's WEB — ${sections.length} sections</div>
+    <div class="doc-title">${escapeHtml(docTitle)}</div>
+    <div class="doc-subtitle">Knuth's WEB &mdash; ${sections.length} sections</div>
   </header>
   ${sectionsHtml}
 </main>

--- a/src/parser.js
+++ b/src/parser.js
@@ -69,13 +69,31 @@ function collectRefs(code) {
  */
 function parseDef(kind, text) {
   // @d name==value  or  @d name=value  or  @d name value
-  // The conventional WEB form is: identifier followed by ==
-  const eqq = text.indexOf('==');
-  if (eqq !== -1) {
-    return { kind, name: text.slice(0, eqq).trim(), value: text.slice(eqq + 2) };
+  // Conventional WEB uses == but many use =.
+  let splitIdx = text.indexOf('==');
+  let sepLen = 2;
+  if (splitIdx === -1) {
+    splitIdx = text.indexOf('=');
+    sepLen = 1;
   }
-  // Fallback: treat whole thing as value
-  return { kind, name: '', value: text };
+
+  if (splitIdx !== -1) {
+    return {
+      kind,
+      name: text.slice(0, splitIdx).trim(),
+      value: text.slice(splitIdx + sepLen).trim()
+    };
+  }
+  // Fallback: split at first space
+  const firstSpace = text.trim().indexOf(' ');
+  if (firstSpace !== -1) {
+    return {
+      kind,
+      name: text.trim().slice(0, firstSpace),
+      value: text.trim().slice(firstSpace + 1)
+    };
+  }
+  return { kind, name: text.trim(), value: '' };
 }
 
 /**
@@ -158,9 +176,19 @@ export function parse(src) {
     const { starred, raw } = sectionBlobs[idx];
 
     let title = '';
+    let partNumber = null;
     let body = raw;
 
     if (starred) {
+      // Knuth's WEB convention: starred titles often start with \[N]
+      // marking the major part number (Part 1, Part 2, etc).
+      // Parse and extract this prefix before scanning for the title-end period.
+      const partMatch = body.match(/^\s*\\\[(\d+)\]\s*/);
+      if (partMatch) {
+        partNumber = Number(partMatch[1]);
+        body = body.slice(partMatch[0].length);
+      }
+
       // Title is text up to the first sentence-ending period.
       // A period is sentence-ending when the preceding word has ≥ 2 characters
       // (to skip single-letter abbreviations like D. or E.).
@@ -325,7 +353,25 @@ export function parse(src) {
       chunkRefs.get(ref).push(num);
     }
 
-    sections.push({ number: num, starred, title, tex, defs, code, chunkName, refs });
+    // Strip WEB index control codes from prose — they're invisible markup
+    // for the index, not body content. Patterns:
+    //   @^...@>     roman index entry
+    //   @.text@>    typewriter index entry
+    //   @:sort}{e@> user-defined index sort key
+    //   @!          force-index marker (when adjacent to @^/@:/@./@<)
+    const cleanTex = tex
+      .replace(/@\^[^@]*@>/g, '')
+      .replace(/@\.[^@]*@>/g, '')
+      .replace(/@:[^@]*@>/g, '')
+      .replace(/@!(?=\s*@[\^.:])/g, '')
+      .replace(/@!(?=\s*@<)/g, '')
+      // \(...) and \9... are sort keys: definitions discard their args
+      .replace(/\\\([^)]*\)/g, '')
+      .replace(/\\9\S*/g, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+
+    sections.push({ number: num, starred, partNumber, title, tex: cleanTex, defs, code, chunkName, refs });
   }
 
   return { sections, chunkDefs, chunkRefs };

--- a/src/tex-to-html.js
+++ b/src/tex-to-html.js
@@ -19,7 +19,19 @@ function escapeHtml(s) {
  */
 function renderMath(math, display) {
   try {
-    return katex.renderToString(math, { displayMode: display, throwOnError: false });
+    return katex.renderToString(math, {
+      displayMode: display,
+      throwOnError: false,
+      macros: {
+        "\\.": "\\texttt{#1}",
+        "\\&": "\\textbf{#1}",
+        "\\|": "\\textit{#1}",
+        "\\PB": "\\text{#1}",
+        "\\sq": "\\square",
+        "\\hang": "",
+        "\\noindent": "",
+      }
+    });
   } catch {
     return `<code class="math-fallback">${escapeHtml(math)}</code>`;
   }
@@ -33,71 +45,87 @@ export function texToHtml(tex) {
   if (!tex) return '';
 
   let s = tex;
+  const placeholders = [];
+  function pushPlaceholder(html) {
+    const id = `\x07P${placeholders.length}\x07`;
+    placeholders.push(html);
+    return id;
+  }
 
-  // --- WEB font commands: process BEFORE math so they don't confuse KaTeX ---
-  // \.{text} → <code>text</code>  (typewriter / identifier)
+  // --- WEB control codes that appear in prose ---
+  s = s.replace(/@!/g, '');
+
+  // --- |...| Pascal code snippets in prose ---
+  s = s.replace(/\|([^|]+)\|/g, (_, code) => pushPlaceholder(`<code>${escapeHtml(code)}</code>`));
+
+  // --- Math: $$...$$ display, $...$ inline ---
+  s = s.replace(/\$\$([\s\S]*?)\$\$/g, (_, m) => pushPlaceholder(renderMath(m, true)));
+  s = s.replace(/\$((?:[^$\\]|\\.)+?)\$/g, (_, m) => pushPlaceholder(renderMath(m, false)));
+
+  // --- WEB font commands ---
   s = s.replace(/\\\.{([^}]*)}/g, (_, t) => `<code>${escapeHtml(t)}</code>`);
-  // \&{text} → <strong>text</strong>
+  s = s.replace(/\\\.([a-zA-Z0-9_])/g, (_, c) => `<code>${escapeHtml(c)}</code>`);
   s = s.replace(/\\&{([^}]*)}/g, (_, t) => `<strong>${escapeHtml(t)}</strong>`);
-  // \|{text} → <em>text</em>
+  s = s.replace(/\\&([a-zA-Z])/g, (_, c) => `<strong>${escapeHtml(c)}</strong>`);
   s = s.replace(/\\\|{([^}]*)}/g, (_, t) => `<em>${escapeHtml(t)}</em>`);
-  // {\tt text}, {\it text}, {\bf text}, {\sl text}
+
   s = s.replace(/\{\\tt\s+([^}]*)\}/g, (_, t) => `<code>${escapeHtml(t)}</code>`);
   s = s.replace(/\{\\it\s+([^}]*)\}/g, (_, t) => `<em>${escapeHtml(t)}</em>`);
   s = s.replace(/\{\\bf\s+([^}]*)\}/g, (_, t) => `<strong>${escapeHtml(t)}</strong>`);
   s = s.replace(/\{\\sl\s+([^}]*)\}/g, (_, t) => `<em class="slanted">${escapeHtml(t)}</em>`);
 
-  // --- Math: $$...$$ display, $...$ inline ---
-  // Process display math first (longer delimiter)
-  s = s.replace(/\$\$([\s\S]*?)\$\$/g, (_, m) => renderMath(m, true));
-  s = s.replace(/\$((?:[^$\\]|\\.)+?)\$/g, (_, m) => renderMath(m, false));
+  // --- Escaped TeX characters ---
+  s = s.replace(/\\{/g, '\x01').replace(/\\}/g, '\x02');
+  s = s.replace(/\\([&%#_$])/g, '$1');
 
-  // --- WEB-specific TeX macros (font commands already handled above) ---
+  // --- Quotes ---
+  s = s.replace(/``/g, '&ldquo;').replace(/''/g, '&rdquo;');
+  s = s.replace(/`([^']*)'/g, '&lsquo;$1&rsquo;');
 
-  // \^{x} → superscript
-  s = s.replace(/\\\^{([^}]*)}/g, (_, t) => `<sup>${escapeHtml(t)}</sup>`);
+  // --- WEB-specific TeX macros ---
+  s = s.replace(/\\\^\{([^}]*)\}/g, (_, t) => `<sup>${escapeHtml(t)}</sup>`);
+  s = s.replace(/_\{([^}]*)\}/g, (_, t) => `<sub>${escapeHtml(t)}</sub>`);
+  s = s.replace(/\\<([^>]*)>/g, (_, t) => `&lang;<em>${escapeHtml(t)}</em>&rang;`);
 
-  // _{x} → subscript (bare form)
-  s = s.replace(/_{([^}]*)}/g, (_, t) => `<sub>${escapeHtml(t)}</sub>`);
-
-  // \TeX → TeX logo
-  s = s.replace(/\\TeX\b/g, '<span class="tex-logo">T<sub>e</sub>X</span>');
-
-  // \MF → METAFONT logo
-  s = s.replace(/\\MF\b/g, '<span class="tex-logo">METAFONT</span>');
-
-  // \WEB → WEB logo
-  s = s.replace(/\\WEB\b/g, '<span class="tex-logo">WEB</span>');
+  // TeX-family compound logos
+  s = s.replace(/\\TeXbook(?!\w)/g, '<span class="tex-logo">T<sub>e</sub>X</span>book');
+  s = s.replace(/\\TeX82(?!\w)/g, '<span class="tex-logo">T<sub>e</sub>X</span>82');
+  s = s.replace(/\\TeX(?!\w)/g, '<span class="tex-logo">T<sub>e</sub>X</span>');
+  s = s.replace(/\\MF(?!\w)/g, '<span class="tex-logo">METAFONT</span>');
+  s = s.replace(/\\WEB(?!\w)/g, '<span class="tex-logo">WEB</span>');
+  s = s.replace(/\\PASCAL(?!\w)/g, '<span class="smallcaps">Pascal</span>');
+  s = s.replace(/\\pct!/g, '%');
+  s = s.replace(/\\ph(?!\w)/g, 'Pascal-H');
 
   // Paragraph breaks
-  s = s.replace(/\n{2,}/g, '</p><p>');
+  s = s.replace(/\n[ \t]*\n+/g, '</p><p>');
 
-  // \\ → <br>
-  s = s.replace(/\\\\/g, '<br>');
+  // Spacing and structural macros
+  s = s.replace(/\\\\(?!\w)/g, '<br>');
+  s = s.replace(/\\hfill(?!\w)/g, '<span class="hfill"></span>');
+  s = s.replace(/\\(small|med|big)skip(?!\w)/g, (_, sz) => `<span class="skip-${sz}"></span>`);
+  s = s.replace(/\\noindent\b/g, '');
+  s = s.replace(/\\yskip\b/g, '<span class="skip-small"></span>');
+  s = s.replace(/\\item\{([^}]*)\}/g, (_, lbl) => `<span class="item"><span class="item-label">${lbl}</span>`);
 
-  // \hfill → flex spacer
-  s = s.replace(/\\hfill\b/g, '<span class="hfill"></span>');
-
-  // \smallskip \medskip \bigskip → spacing divs
-  s = s.replace(/\\(small|med|big)skip\b/g, (_, sz) => `<div class="skip-${sz}"></div>`);
-
-  // \noindent
-  s = s.replace(/\\noindent\b\s*/g, '');
-
-  // \quad \qquad → non-breaking spaces
-  s = s.replace(/\\qquad\b/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
-  s = s.replace(/\\quad\b/g, '&nbsp;&nbsp;');
-
-  // ~ → non-breaking space
+  s = s.replace(/\\qquad(?!\w)/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
+  s = s.replace(/\\quad(?!\w)/g, '&nbsp;&nbsp;');
   s = s.replace(/(?<!\\)~/g, '&nbsp;');
+  s = s.replace(/\\\s/g, ' ');
 
-  // Remaining unknown macros: wrap in span so they're visible
-  s = s.replace(/\\[a-zA-Z]+\b/g, m => `<span class="tex-unknown">${escapeHtml(m)}</span>`);
+  // Clean up unknown macros
+  s = s.replace(/\\[a-zA-Z]+\b/g, '');
 
-  // Escape remaining HTML-unsafe characters (outside of spans we already built)
-  // We can't do a simple escapeHtml here since we've already inserted HTML.
-  // Instead we replace stray < > & that aren't part of tags.
-  // This is a best-effort approach for the TeX source's non-math content.
+  // Stray { } from TeX grouping
+  s = s.replace(/[{}]/g, '');
+
+  // Restore escaped braces
+  s = s.replace(/\x01/g, '{').replace(/\x02/g, '}');
+
+  // Restore placeholders
+  s = s.replace(/\x07P(\d+)\x07/g, (_, i) => placeholders[Number(i)]);
+
+  // & (unencoded)
   s = s.replace(/&(?![a-zA-Z#\d]+;)/g, '&amp;');
 
   return `<p>${s}</p>`;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1,65 +1,61 @@
-/* Computer Modern web fonts (served from CTAN) */
+/* dekweb — book-flow viewer for Knuth's WEB
+   Design goal: emulate the TeX-typeset PDF: white paper, black ink,
+   Computer Modern, tight justified prose, bold inline section markers. */
+
 @font-face {
-  font-family: 'Computer Modern';
-  src: url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif.woff2') format('woff2'),
-       url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
+  font-family: 'Computer Modern Serif';
+  src: url('https://cdn.jsdelivr.net/gh/dreampulse/computer-modern-web-font@master/fonts/Serif/cmun-serif.woff') format('woff');
+  font-weight: normal; font-style: normal;
 }
 @font-face {
-  font-family: 'Computer Modern';
-  src: url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif-italic.woff2') format('woff2'),
-       url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif-italic.woff') format('woff');
-  font-weight: normal;
-  font-style: italic;
+  font-family: 'Computer Modern Serif';
+  src: url('https://cdn.jsdelivr.net/gh/dreampulse/computer-modern-web-font@master/fonts/Serif/cmun-serif-italic.woff') format('woff');
+  font-weight: normal; font-style: italic;
 }
 @font-face {
-  font-family: 'Computer Modern';
-  src: url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif-bold.woff2') format('woff2'),
-       url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-serif-bold.woff') format('woff');
-  font-weight: bold;
-  font-style: normal;
+  font-family: 'Computer Modern Serif';
+  src: url('https://cdn.jsdelivr.net/gh/dreampulse/computer-modern-web-font@master/fonts/Serif-Bold/cmun-serif-bold.woff') format('woff');
+  font-weight: bold; font-style: normal;
 }
 @font-face {
-  font-family: 'Computer Modern Mono';
-  src: url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-typewriter.woff2') format('woff2'),
-       url('https://cdn.jsdelivr.net/npm/computer-modern@0.1.2/cmu-typewriter.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
+  font-family: 'Computer Modern Typewriter';
+  src: url('https://cdn.jsdelivr.net/gh/dreampulse/computer-modern-web-font@master/fonts/Typewriter-Light/cmun-typewriter-light.woff') format('woff');
+  font-weight: normal; font-style: normal;
 }
 
-/* ── Reset & Base ─────────────────────────────────────────────────────────── */
+/* ── Reset ────────────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --ink:        #1a1a1a;
-  --ink-light:  #444;
-  --paper:      #faf8f3;
-  --paper-alt:  #f2ede3;
-  --rule:       #c8bfaa;
-  --accent:     #7b3f00;       /* warm dark amber — like printer's ink */
-  --code-bg:    #1e1c18;
-  --code-ink:   #e8e0d0;
-  --link:       #5c3317;
-  --link-hover: #a0522d;
-  --font-body:  'Computer Modern', Palatino, 'Book Antiqua', Georgia, serif;
-  --font-mono:  'Computer Modern Mono', 'Courier New', Courier, monospace;
-  --max-prose:  68ch;
-  --max-code:   90ch;
-  --sidebar-w:  260px;
+  --ink:        #111;
+  --ink-light:  #555;
+  --paper:      #ffffff;
+  --paper-soft: #fafafa;
+  --rule:       #ccc;
+  --link:       #1a4480;
+  --link-hover: #c14a09;
+  --code-bg:    #f5f3ee;
+  --font-body:  'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
+  --font-mono:  'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
+  --text-w:     38em;     /* prose column width — like the PDF (≈5.5in / 11pt ≈ 38em) */
+  --code-w:     42em;     /* code block max width */
+  --sidebar-w:  240px;
 }
 
-html { font-size: 17px; scroll-behavior: smooth; }
+html { font-size: 16px; scroll-behavior: smooth; }
 
 body {
   background: var(--paper);
   color: var(--ink);
   font-family: var(--font-body);
-  line-height: 1.65;
+  font-size: 1rem;
+  line-height: 1.45;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
   display: flex;
 }
 
-/* ── Sidebar (TOC) ─────────────────────────────────────────────────────────── */
+/* ── Sidebar (TOC) ────────────────────────────────────────────────────────── */
 #sidebar {
   width: var(--sidebar-w);
   min-width: var(--sidebar-w);
@@ -67,10 +63,10 @@ body {
   position: sticky;
   top: 0;
   overflow-y: auto;
-  background: var(--paper-alt);
+  background: var(--paper-soft);
   border-right: 1px solid var(--rule);
-  padding: 1.5rem 0;
-  transition: width 0.2s, min-width 0.2s;
+  padding: 1.25rem 0 2rem;
+  font-size: 0.85rem;
 }
 
 #sidebar.collapsed {
@@ -78,17 +74,36 @@ body {
   min-width: 0;
   overflow: hidden;
   padding: 0;
+  border: none;
 }
 
 #sidebar h2 {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   color: var(--ink-light);
-  padding: 0 1rem 0.75rem;
+  font-weight: normal;
+  padding: 0 1rem 0.5rem;
+  margin-bottom: 0.4rem;
   border-bottom: 1px solid var(--rule);
-  margin-bottom: 0.5rem;
 }
+
+#search-wrap {
+  padding: 0.5rem 0.75rem 0.75rem;
+}
+
+#search {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.78rem;
+  font-family: var(--font-body);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+#search:focus { outline: 1px solid var(--ink); border-color: var(--ink); }
 
 #toc {
   list-style: none;
@@ -97,164 +112,221 @@ body {
 
 #toc li a {
   display: flex;
+  align-items: baseline;
   gap: 0.5rem;
-  padding: 0.3rem 0.5rem;
-  border-radius: 3px;
+  padding: 0.18rem 0.5rem;
   font-size: 0.82rem;
-  line-height: 1.35;
+  line-height: 1.3;
   color: var(--link);
   text-decoration: none;
-  transition: background 0.1s;
-}
-
-#toc li a:hover { background: rgba(0,0,0,0.06); color: var(--link-hover); }
-#toc li a.active { background: rgba(0,0,0,0.09); font-weight: bold; }
-
-#toc .sec-num {
-  color: var(--ink-light);
-  font-size: 0.75rem;
-  flex-shrink: 0;
-  padding-top: 0.05em;
-}
-
-/* ── Main content ──────────────────────────────────────────────────────────── */
-#main {
-  flex: 1;
-  min-width: 0;
-  padding: 3rem 4rem 6rem;
-  max-width: calc(var(--max-code) + 8rem);
-}
-
-/* ── Document header ───────────────────────────────────────────────────────── */
-#doc-header {
-  margin-bottom: 3rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 2px solid var(--ink);
-}
-
-#doc-header h1 {
-  font-size: 2.2rem;
-  letter-spacing: -0.02em;
-  line-height: 1.15;
-}
-
-#doc-header .subtitle {
-  color: var(--ink-light);
-  font-size: 0.9rem;
-  margin-top: 0.4rem;
-}
-
-/* ── Sections ──────────────────────────────────────────────────────────────── */
-.section {
-  display: grid;
-  grid-template-columns: 3.5rem 1fr;
-  column-gap: 1.25rem;
-  margin-bottom: 2rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid var(--rule);
-}
-
-.section:last-child { border-bottom: none; }
-
-.section.starred {
-  margin-top: 3.5rem;
-  padding-top: 1rem;
-  border-top: 2px solid var(--ink);
-}
-
-.section-num {
-  grid-column: 1;
-  text-align: right;
-  color: var(--ink-light);
-  font-size: 0.78rem;
-  padding-top: 0.35em;
-  user-select: none;
-}
-
-.section-num a {
-  color: inherit;
-  text-decoration: none;
-}
-.section-num a:hover { color: var(--accent); }
-
-.section-body {
-  grid-column: 2;
-  min-width: 0;
-}
-
-/* Starred section title */
-.section-title {
-  font-size: 1.25rem;
-  font-weight: bold;
-  margin-bottom: 0.75rem;
-  color: var(--accent);
-  letter-spacing: -0.01em;
-}
-
-/* ── Prose (TeX) ───────────────────────────────────────────────────────────── */
-.tex-prose {
-  max-width: var(--max-prose);
-}
-
-.tex-prose p { margin-bottom: 0.85em; }
-.tex-prose p:last-child { margin-bottom: 0; }
-
-.tex-prose code {
-  font-family: var(--font-mono);
-  font-size: 0.88em;
-  background: rgba(0,0,0,0.06);
-  padding: 0.05em 0.25em;
   border-radius: 2px;
 }
 
-.tex-unknown {
-  color: #999;
-  font-size: 0.85em;
+#toc li a:hover { background: rgba(0,0,0,0.04); color: var(--link-hover); }
+#toc li a.active { background: rgba(0,0,0,0.07); color: var(--ink); font-weight: bold; }
+
+#toc .sec-num {
+  color: var(--ink-light);
+  font-size: 0.72rem;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  min-width: 2.5rem;
+}
+
+#toc .part-num {
+  color: var(--link-hover);
+  font-weight: bold;
+  font-size: 0.7rem;
+  min-width: 2.5rem;
+}
+
+/* ── Main area ────────────────────────────────────────────────────────────── */
+#main {
+  flex: 1;
+  min-width: 0;
+  padding: 4rem 3rem 6rem 4rem;
+  max-width: calc(var(--code-w) + 8rem);
+}
+
+/* Document header — minimal, like the PDF's title-page area */
+#doc-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+#doc-header .doc-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  letter-spacing: 0.04em;
+}
+
+#doc-header .doc-subtitle {
+  font-size: 0.78rem;
+  color: var(--ink-light);
+  margin-top: 0.25rem;
+  font-style: italic;
+}
+
+/* ── Sections ─────────────────────────────────────────────────────────────── */
+.section {
+  margin: 0;
+  padding: 0.65rem 0 0.65rem 0;
+  position: relative;
+  /* Section number floats in the left margin */
+  padding-left: 3rem;
+  scroll-margin-top: 1rem;
+}
+
+/* The section-num is shown in the left margin (small, gray) */
+.section-num {
+  position: absolute;
+  left: 0;
+  top: 0.65rem;
+  width: 2.5rem;
+  text-align: right;
+  font-size: 0.78rem;
+  color: var(--ink-light);
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}
+
+.section-num a { color: inherit; text-decoration: none; }
+.section-num a:hover { color: var(--link-hover); }
+
+/* Starred sections get a chapter-level break */
+.section.starred {
+  margin-top: 4rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--ink);
+}
+
+/* The first section never needs a top break */
+.section.starred:first-of-type {
+  margin-top: 0;
+}
+
+.section-title {
+  font-size: 1.05rem;
+  font-weight: bold;
+  margin-bottom: 0.35rem;
+  letter-spacing: 0.01em;
+}
+
+.section-title .part-label {
+  color: var(--ink-light);
+  font-size: 0.78rem;
+  font-weight: normal;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+/* The bold inline section number that opens prose paragraphs.
+   Mirrors the PDF's "1. Introduction." form when the section has a title,
+   or just "1." when it doesn't. */
+.section-marker {
+  font-weight: bold;
+  margin-right: 0.4em;
+}
+
+/* ── Prose ────────────────────────────────────────────────────────────────── */
+.tex-prose {
+  max-width: var(--text-w);
+  text-align: justify;
+  hyphens: auto;
+  -webkit-hyphens: auto;
+}
+
+.tex-prose p { margin: 0 0 0.4em 0; text-indent: 0; }
+.tex-prose p + p { text-indent: 1.5em; margin-top: 0; } /* book-style indent on continuation paragraphs */
+
+.tex-prose code {
   font-family: var(--font-mono);
+  font-size: 0.9em;
+  letter-spacing: 0;
+  /* No background — the PDF doesn't tint inline code. */
+}
+
+.tex-prose strong { font-weight: bold; }
+.tex-prose em { font-style: italic; }
+
+.tex-prose em.slanted { font-style: normal; font-family: 'Computer Modern Serif', serif; font-variant-caps: normal; transform: skewX(-12deg); display: inline-block; }
+
+.item {
+  display: flex;
+  margin: 0.2rem 0;
+  padding-left: 1.5rem;
+  position: relative;
+}
+
+.item-label {
+  position: absolute;
+  left: 0;
+  font-weight: bold;
+}
+
+.smallcaps {
+  font-variant-caps: small-caps;
+  letter-spacing: 0.04em;
+}
+
+/* TeX-family logos: emulate the lowered uppercase E */
+.tex-logo {
+  font-family: var(--font-body);
+  letter-spacing: 0;
+}
+
+.tex-logo sub {
+  font-size: 0.92em;
+  vertical-align: -0.18em;
+  margin: 0 -0.07em;
 }
 
 /* KaTeX display blocks */
 .katex-display {
-  margin: 1rem 0;
+  margin: 0.6rem 0;
   overflow-x: auto;
 }
 
-/* ── Macro definitions (@d / @f) ───────────────────────────────────────────── */
+/* ── Macro definitions (@d / @f) ──────────────────────────────────────────── */
 .defs {
-  margin: 0.75rem 0;
+  margin: 0.4rem 0 0.5rem 0;
+  font-size: 0.88rem;
 }
 
 .def-entry {
-  display: flex;
-  gap: 0.5rem;
   font-family: var(--font-mono);
-  font-size: 0.82rem;
-  color: var(--ink-light);
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.1rem;
+  display: flex;
   flex-wrap: wrap;
+  gap: 0.35em;
+  align-items: baseline;
+  color: var(--ink);
 }
 
 .def-kind {
-  color: var(--accent);
-  font-weight: bold;
+  font-style: italic;
+  color: var(--ink-light);
+  font-family: var(--font-body);
   flex-shrink: 0;
 }
 
-.def-name { color: var(--ink); }
+.def-name { font-weight: bold; }
 .def-sep  { color: var(--ink-light); }
-.def-val  { color: #555; word-break: break-all; }
+.def-val  { word-break: normal; }
 
-/* ── Code blocks ───────────────────────────────────────────────────────────── */
+/* ── Code blocks ──────────────────────────────────────────────────────────── */
 .code-block-wrap {
-  margin: 0.75rem 0 0;
-  position: relative;
+  margin: 0.45rem 0 0.4rem 0;
 }
 
 .chunk-label {
   font-family: var(--font-mono);
-  font-size: 0.8rem;
-  color: var(--ink-light);
-  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+  margin-bottom: 0.2rem;
 }
 
 .chunk-label a { color: var(--link); text-decoration: none; }
@@ -262,79 +334,78 @@ body {
 
 pre.code-block {
   background: var(--code-bg);
-  color: var(--code-ink);
+  color: var(--ink);
   font-family: var(--font-mono);
-  font-size: 0.83rem;
-  line-height: 1.55;
-  padding: 1rem 1.25rem;
-  border-radius: 4px;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
   overflow-x: auto;
-  max-width: var(--max-code);
+  max-width: var(--code-w);
   tab-size: 4;
   -moz-tab-size: 4;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
-/* chunk refs inside code: §N style links */
+/* Override Prism's tomorrow theme to keep our paper-like aesthetic */
+pre.code-block .token.comment    { color: #777; font-style: italic; }
+pre.code-block .token.keyword    { color: #003366; font-weight: bold; }
+pre.code-block .token.string     { color: #663300; }
+pre.code-block .token.number     { color: #663300; }
+pre.code-block .token.operator   { color: #444; }
+pre.code-block .token.punctuation{ color: #444; }
+pre.code-block .token.function   { color: #1a4480; }
+
 .chunk-ref {
-  color: #aad4ff;
+  color: var(--link);
   text-decoration: none;
   font-style: italic;
 }
-.chunk-ref:hover { text-decoration: underline; color: #cce5ff; }
+.chunk-ref:hover { text-decoration: underline; color: var(--link-hover); }
+.chunk-ref.unresolved { color: var(--ink-light); cursor: help; }
 
-/* ── Search ────────────────────────────────────────────────────────────────── */
-#search-wrap {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--rule);
-}
-
-#search {
-  width: 100%;
-  padding: 0.35rem 0.6rem;
-  font-size: 0.82rem;
-  font-family: var(--font-body);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
-  background: var(--paper);
-  color: var(--ink);
-}
-
-#search:focus { outline: 2px solid var(--accent); border-color: transparent; }
-
-/* ── Toggle button ─────────────────────────────────────────────────────────── */
+/* ── Toggle button ────────────────────────────────────────────────────────── */
 #toggle-sidebar {
   position: fixed;
-  top: 0.75rem;
-  left: 0.75rem;
+  top: 0.5rem;
+  left: 0.5rem;
   z-index: 100;
-  background: var(--paper-alt);
+  background: var(--paper-soft);
   border: 1px solid var(--rule);
-  border-radius: 3px;
+  border-radius: 2px;
   cursor: pointer;
-  font-size: 1.1rem;
+  font-size: 1rem;
   line-height: 1;
-  padding: 0.3rem 0.5rem;
+  padding: 0.25rem 0.45rem;
   color: var(--ink);
+  font-family: var(--font-body);
 }
+#toggle-sidebar:hover { background: var(--rule); }
 
-/* ── Utility ───────────────────────────────────────────────────────────────── */
-.tex-logo { font-family: var(--font-body); letter-spacing: 0.02em; }
+/* ── Utility ──────────────────────────────────────────────────────────────── */
 .hfill { flex: 1; }
-.skip-small { height: 0.5rem; }
-.skip-med   { height: 1rem; }
-.skip-big   { height: 1.75rem; }
+.skip-small { height: 0.4rem; }
+.skip-med   { height: 0.7rem; }
+.skip-big   { height: 1.2rem; }
+.tex-unknown { color: #c00; font-style: italic; font-family: var(--font-mono); font-size: 0.85em; }
 
-/* ── Print ─────────────────────────────────────────────────────────────────── */
+/* ── Print ────────────────────────────────────────────────────────────────── */
 @media print {
-  #sidebar, #toggle-sidebar { display: none; }
+  #sidebar, #toggle-sidebar { display: none !important; }
+  body { font-size: 10.5pt; }
   #main { padding: 0; max-width: 100%; }
-  pre.code-block { background: #f4f4f4; color: #111; border: 1px solid #ccc; }
+  pre.code-block { background: #f6f4ed; }
   a { color: inherit; text-decoration: none; }
   .section { break-inside: avoid; }
+  .section.starred { break-before: page; }
 }
 
-/* ── Responsive ────────────────────────────────────────────────────────────── */
-@media (max-width: 700px) {
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 760px) {
   #sidebar { display: none; }
   #main { padding: 1.5rem 1rem 4rem; }
+  .section { padding-left: 0; }
+  .section-num { position: static; text-align: left; margin-bottom: 0.2rem; }
 }


### PR DESCRIPTION
This PR addresses several rendering issues in the WEB viewer and introduces a Makefile for better build management.

### Changes:
- **Parser Improvements**: Better definition parsing (handles = and ==) and removal of index markers from prose.
- **TeX-to-HTML Refactor**:
    - Implemented a placeholder strategy to protect Pascal code snippets and math from being mangled.
    - Added support for escaped characters, smart quotes, and numerous WEB-specific TeX macros.
    - Added KaTeX macro definitions to handle \., \&, \|, etc.
- **Pascal Code Rendering**: Stripped WEB format control codes from Prism-highlighted blocks.
- **Visual Design**: Updated CSS to match the Computer Modern / PDF aesthetic more closely, including slanted text and list items.
- **Build System**: Added a Makefile for one-command generation of both HTML and PDF reference outputs.
