### PR TITLE
Fix: strip WEB index entries from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# dekweb
+
+Aesthetically-pleasing browser viewer for Donald Knuth's WEB literate programs.
+
+## Project Overview
+
+`dekweb` is a Node.js-based toolchain designed to convert classic WEB literate programming files into modern, interactive HTML documents. It specifically targets the core TeX system components (Tangle, Weave, and TeX itself), providing a searchable, cross-referenced, and syntax-highlighted web interface for exploring the source code.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (Latest LTS recommended)
+- `weave` and `pdftex` (Optional, only required for PDF generation)
+
+### Installation
+
+```bash
+git clone https://github.com/stmartinerael/dekweb.git
+cd dekweb
+make setup
+```
+
+## Usage
+
+### Building the Viewer
+
+To build the HTML viewer for all core WEB sources:
+
+```bash
+npm run build
+```
+
+The output will be generated in the `output/` directory.
+
+### Running Tests
+
+```bash
+npm test
+```
+
+## Architecture
+
+- **`src/parser.js`**: Custom WEB format parser.
+- **`src/tex-to-html.js`**: TeX prose to HTML converter using KaTeX.
+- **`src/build.js`**: Main build orchestrator and code renderer.
+- **`viewer/`**: Frontend assets (CSS/JS) for the interactive viewer.
+
+## License
+
+ISC

--- a/src/build.js
+++ b/src/build.js
@@ -49,12 +49,10 @@ function renderCode(raw, chunkDefs) {
     .replace(/@&/g, '')                            // @& (concatenate)
     .replace(/@\+/g, '')                           // @+ (indent)
     .replace(/@;/g, '')                            // @; (semicolon)
-    .replace(/@\./g, '')                           // @. (typewriter)
-    .replace(/@:/g, '')                            // @: (index)
-    .replace(/@\^/g, '')                           // @^ (index)
-    .replace(/@=[^@]*@>/g, m => m.slice(2, -2))   // @=verbatim@> → verbatim
+    .replace(/@[.:\^][^@]*@>/g, '')                // @. @: @^ index entries
+    .replace(/@=[^@]*@>/g, m => m.slice(2, -2))    // @=verbatim@> → verbatim
     .replace(/@'[^']*'/g, m => m)                  // @'x' character literal
-    .replace(/@"0-9a-fA-F]*/g, m => m);           // @"hex
+    .replace(/@"0-9a-fA-F]*/g, m => m);            // @"hex
 
 
   // Prism highlight


### PR DESCRIPTION
Index entries like @:..., @^..., and @.... were not being fully removed from code blocks in src/build.js, leading to visual noise and syntax highlighting artifacts.

Also adds a README.md with project overview and usage instructions.