### PR TITLE
Feat: implement identifier indexing

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -158,14 +158,40 @@ function buildToc(sections) {
         : `<span class="sec-num">§${s.number}</span>`;
       return `<li><a href="#s${s.number}">${lead}<span class="toc-label">${label}</span></a></li>`;
     });
+  // Add Index link
+  items.push(`<li><a href="#index"><span class="sec-num">Index</span><span class="toc-label">Alphabetical Index</span></a></li>`);
   return `<ul id="toc">\n${items.join('\n')}\n</ul>`;
+}
+
+/**
+ * Render the alphabetical index.
+ */
+function renderIndex(indexMap) {
+  const sortedIds = Array.from(indexMap.keys()).sort((a, b) => 
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
+
+  let html = '<div id="index" class="section starred">\n';
+  html += '<div class="section-num">Index</div>\n';
+  html += '<div class="section-body">\n';
+  html += '<div class="section-title">Alphabetical Index.</div>\n';
+  html += '<ul class="index-list">\n';
+
+  for (const id of sortedIds) {
+    const nums = indexMap.get(id).sort((a, b) => a - b);
+    const links = nums.map(n => `<a href="#s${n}">${n}</a>`).join(', ');
+    html += `<li><span class="index-id">${escapeHtml(id)}</span>: ${links}</li>\n`;
+  }
+
+  html += '</ul>\n</div>\n</div>\n';
+  return html;
 }
 
 async function buildFile(name) {
   const src = await readFile(join(ROOT, 'web-sources', name), 'utf8');
   console.log(`Parsing ${name}...`);
-  const { sections, chunkDefs } = parse(src);
-  console.log(`  ${sections.length} sections, ${chunkDefs.size} chunk definitions`);
+  const { sections, chunkDefs, indexMap } = parse(src);
+  console.log(`  ${sections.length} sections, ${chunkDefs.size} chunk definitions, ${indexMap.size} index entries`);
 
   const css = await readFile(join(ROOT, 'viewer', 'style.css'), 'utf8');
   const js = await readFile(join(ROOT, 'viewer', 'viewer.js'), 'utf8');
@@ -184,6 +210,7 @@ async function buildFile(name) {
 
   console.log(`  Rendering sections...`);
   const sectionsHtml = sections.map(s => renderSection(s, chunkDefs)).join('\n');
+  const indexHtml = renderIndex(indexMap);
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -211,6 +238,7 @@ ${fontCss}
     <div class="doc-subtitle">Knuth's WEB &mdash; ${sections.length} sections</div>
   </header>
   ${sectionsHtml}
+  ${indexHtml}
 </main>
 <script>${js}</script>
 </body>

--- a/src/parser.js
+++ b/src/parser.js
@@ -99,14 +99,22 @@ function parseDef(kind, text) {
 /**
  * Main parse function.
  * @param {string} src  Full text of a .web file
- * @returns {{ sections: Section[], chunkDefs: Map, chunkRefs: Map }}
+ * @returns {{ sections: Section[], chunkDefs: Map, chunkRefs: Map, indexMap: Map }}
  */
 export function parse(src) {
   const sections = [];
   const chunkDefs = new Map(); // chunkName -> [sectionNumber, ...]
   const chunkRefs = new Map(); // chunkName -> [sectionNumber, ...]
+  const indexMap = new Map();  // identifier -> sectionNumbers[]
+
+  function addIndex(id, num) {
+    if (!indexMap.has(id)) indexMap.set(id, []);
+    const nums = indexMap.get(id);
+    if (!nums.includes(num)) nums.push(num);
+  }
 
   // --- Tokenise into raw section blobs ---
+  // ... (rest of tokenisation logic is unchanged)
   // A section starts with:
   //   @ <space>   (unnamed)
   //   @\n         (unnamed)
@@ -343,6 +351,54 @@ export function parse(src) {
     // Collect chunk refs from code
     const refs = collectRefs(code);
 
+    // --- Collect index entries ---
+
+    // 1. Manual index entries (@^, @., @:) from both TeX and code
+    const collectManual = (text) => {
+      const re = /@([\^.:])([^@]+)@>/g;
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        const kind = m[1];
+        const val = m[2].trim();
+        // For simplicity, we just index the raw text. 
+        // weave handles @. differently (typewriter), but here we consolidated them.
+        addIndex(val, num);
+      }
+    };
+    collectManual(tex);
+    collectManual(code);
+    for (const d of defs) collectManual(d.value);
+
+    // 2. Pascal identifiers from code
+    const collectIdentifiers = (text) => {
+      // Basic Pascal identifier regex
+      const re = /\b[a-zA-Z][a-zA-Z0-9_]*\b/g;
+      const keywords = new Set([
+        'and', 'array', 'begin', 'case', 'const', 'div', 'do', 'downto', 'else', 'end',
+        'file', 'for', 'function', 'goto', 'if', 'in', 'label', 'mod', 'nil', 'not',
+        'of', 'or', 'packed', 'procedure', 'program', 'record', 'repeat', 'set',
+        'then', 'to', 'type', 'until', 'var', 'while', 'with'
+      ]);
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        const id = m[0].toLowerCase();
+        if (!keywords.has(id) && id.length > 2) {
+          addIndex(m[0], num); // Use original casing for display? No, weave often case-folds.
+          // Knuth's Pascal is mostly case-insensitive.
+        }
+      }
+    };
+    collectIdentifiers(code);
+
+    // 3. Macro names from @d
+    for (const d of defs) {
+      if (d.kind === 'd') addIndex(d.name, num);
+    }
+
+    // 4. Chunk names
+    if (chunkName) addIndex(chunkName, num);
+
+
     // Update cross-reference maps
     if (chunkName) {
       if (!chunkDefs.has(chunkName)) chunkDefs.set(chunkName, []);
@@ -374,5 +430,5 @@ export function parse(src) {
     sections.push({ number: num, starred, partNumber, title, tex: cleanTex, defs, code, chunkName, refs });
   }
 
-  return { sections, chunkDefs, chunkRefs };
+  return { sections, chunkDefs, chunkRefs, indexMap };
 }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -227,3 +227,30 @@ test('double-starred section @** treated like starred @*', () => {
   assert.equal(s[0].starred, true);
   assert.equal(s[0].title, 'Big Title');
 });
+
+// ── Indexing ──────────────────────────────────────────────────────────────────
+
+test('manual index entries are collected', () => {
+  const src = '@* Title. See @^system dependencies@> and @.typewriter@>.';
+  const { indexMap } = parse(src);
+  assert.ok(indexMap.has('system dependencies'));
+  assert.ok(indexMap.has('typewriter'));
+  assert.deepEqual(indexMap.get('system dependencies'), [1]);
+});
+
+test('Pascal identifiers are indexed', () => {
+  const src = '@ @p procedure PrintBanner; begin banner := 1; end;';
+  const { indexMap } = parse(src);
+  assert.ok(indexMap.has('PrintBanner'));
+  assert.ok(indexMap.has('banner'));
+  // procedure, begin, end are keywords and should NOT be indexed
+  assert.ok(!indexMap.has('procedure'));
+  assert.ok(!indexMap.has('begin'));
+});
+
+test('macro names and chunk names are indexed', () => {
+  const src = '@ @d max_val==100\n@<My Chunk@>=x:=1;';
+  const { indexMap } = parse(src);
+  assert.ok(indexMap.has('max_val'));
+  assert.ok(indexMap.has('My Chunk'));
+});

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -424,6 +424,32 @@ pre.code-block .token.function   { color: #1a4480; }
   line-height: 1;
 }
 
+/* ── Index ────────────────────────────────────────────────────────────────── */
+.index-list {
+  list-style: none;
+  padding: 0;
+  column-width: 14rem;
+  column-gap: 2rem;
+  font-size: 0.88rem;
+}
+
+.index-list li {
+  break-inside: avoid;
+  margin-bottom: 0.15rem;
+  line-height: 1.3;
+}
+
+.index-id {
+  font-weight: bold;
+  font-family: var(--font-mono);
+}
+
+.index-list a {
+  color: var(--link);
+  text-decoration: none;
+}
+.index-list a:hover { text-decoration: underline; }
+
 /* ── Reporting UI ────────────────────────────────────────────────────────── */
 #report-btn {
   position: absolute;


### PR DESCRIPTION
- Update parser.js to collect manual index entries (@^, @., @:), Pascal identifiers, macro names, and chunk names.
- Update build.js to render a sorted alphabetical index at the end of the document.
- Add alphabetical index link to the Table of Contents.
- Add CSS styling for multi-column index layout.
- Add unit tests for index collection in parser.test.js.

Closes #8
