### PR TITLE
Overhaul UI: warm typography, Computer Modern prose, force-directed g…

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -187,6 +187,33 @@ function renderIndex(indexMap) {
   return html;
 }
 
+function buildGraphData(sections, chunkDefs) {
+  const nodes = sections.map(s => ({
+    id: `s${s.number}`,
+    num: s.number,
+    starred: s.starred,
+    title: s.title || null,
+  }));
+
+  const edgeSet = new Set();
+  const edges = [];
+  for (const sec of sections) {
+    if (!sec.code?.trim()) continue;
+    for (const [, name] of sec.code.matchAll(/@<([^@]*)@>/g)) {
+      const defNums = chunkDefs.get(name.trim()) || [];
+      for (const defNum of defNums) {
+        if (defNum === sec.number) continue;
+        const key = `s${sec.number}->s${defNum}`;
+        if (!edgeSet.has(key)) {
+          edgeSet.add(key);
+          edges.push({ source: `s${sec.number}`, target: `s${defNum}`, label: name.trim() });
+        }
+      }
+    }
+  }
+  return { nodes, edges };
+}
+
 async function buildFile(name) {
   const src = await readFile(join(ROOT, 'web-sources', name), 'utf8');
   console.log(`Parsing ${name}...`);
@@ -200,13 +227,14 @@ async function buildFile(name) {
   const katexCss = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">`;
   // Prism theme
   const prismCss = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">`;
-  // Modern font (Inter)
+  // Fonts (Inter for UI, JetBrains Mono for code)
   const fontCss = `<link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">`;
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">`;
 
   const docTitle = basename(name, '.web').toUpperCase();
   const tocHtml = buildToc(sections);
+  const graphData = buildGraphData(sections, chunkDefs);
 
   console.log(`  Rendering sections...`);
   const sectionsHtml = sections.map(s => renderSection(s, chunkDefs)).join('\n');
@@ -225,6 +253,7 @@ ${fontCss}
 </head>
 <body>
 <button id="toggle-sidebar" title="Toggle table of contents">✕</button>
+<button id="toggle-graph" title="Section graph view">⬡</button>
 <nav id="sidebar">
   <h2>Contents</h2>
   <div id="search-wrap">
@@ -240,6 +269,19 @@ ${fontCss}
   ${sectionsHtml}
   ${indexHtml}
 </main>
+<div id="graph-overlay" hidden>
+  <div id="graph-toolbar">
+    <span id="graph-title">Section Graph &mdash; ${escapeHtml(docTitle)}</span>
+    <button id="graph-close">✕</button>
+  </div>
+  <svg id="graph-svg"></svg>
+  <div id="graph-legend">
+    <span>&#9679; Chapter section</span>
+    <span>&#9675; Regular section</span>
+    <span style="opacity:0.6">Drag to rearrange &nbsp;&middot;&nbsp; Scroll to zoom &nbsp;&middot;&nbsp; Click node to navigate</span>
+  </div>
+</div>
+<script>window.__GRAPH_DATA__ = ${JSON.stringify(graphData)};</script>
 <script>${js}</script>
 </body>
 </html>`;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1,6 +1,6 @@
 /* dekweb — book-flow viewer for Knuth's WEB
-   Design goal: emulate the TeX-typeset PDF: white paper, black ink,
-   Computer Modern, tight justified prose, bold inline section markers. */
+   Design goal: emulate the TeX-typeset PDF: warm paper, warm ink,
+   Computer Modern prose, tight justified text, bold inline section markers. */
 
 @font-face {
   font-family: 'Computer Modern Serif';
@@ -27,34 +27,34 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --ink:        #111;
-  --ink-light:  #555;
-  --paper:      #ffffff;
-  --paper-soft: #fafafa;
-  --rule:       #ccc;
-  --link:       #1a4480;
-  --link-hover: #c14a09;
-  --code-bg:    #f5f3ee;
+  --ink:        #1c1814;
+  --ink-light:  #6b6358;
+  --paper:      #fdfaf4;
+  --paper-soft: #f5f0e8;
+  --rule:       #d9d3c6;
+  --link:       #1a3f6f;
+  --link-hover: #b84309;
+  --code-bg:    #f0ece3;
   --font-body:  'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-prose: 'Computer Modern Serif', Georgia, serif;
   --font-mono:  'JetBrains Mono', 'Fira Code', 'Computer Modern Typewriter', monospace;
-  --text-w:     38em;     /* prose column width — like the PDF (≈5.5in / 11pt ≈ 38em) */
-  --code-w:     42em;     /* code block max width */
-  --sidebar-w:  240px;
+  --text-w:     38em;
+  --code-w:     42em;
+  --sidebar-w:  260px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --ink:        #839496; /* base0 */
+    --ink:        #93a1a1; /* base1 — slightly brighter than before */
     --ink-light:  #586e75; /* base01 */
     --paper:      #002b36; /* base03 */
     --paper-soft: #073642; /* base02 */
-    --rule:       #073642; /* base02 */
-    --link:       #268bd2; /* blue */
-    --link-hover: #cb4b16; /* orange */
-    --code-bg:    #00212b; /* slightly darker than base03 */
+    --rule:       #0d3a47;
+    --link:       #268bd2;
+    --link-hover: #cb4b16;
+    --code-bg:    #001e27;
   }
 
-  /* Override Prism tokens for Solarized Dark */
   pre.code-block .token.comment    { color: #586e75; }
   pre.code-block .token.keyword    { color: #859900; }
   pre.code-block .token.string     { color: #2aa198; }
@@ -63,8 +63,10 @@
   pre.code-block .token.punctuation{ color: #93a1a1; }
   pre.code-block .token.function   { color: #268bd2; }
 
-  /* Adjust KaTeX for dark mode */
   .katex { color: var(--ink); }
+
+  #graph-svg line { stroke: #1a4455; }
+  #graph-svg circle { stroke: #1a4455; }
 }
 
 html { font-size: 16px; scroll-behavior: smooth; }
@@ -79,6 +81,8 @@ body {
   -webkit-font-smoothing: antialiased;
   display: flex;
 }
+
+a { transition: color 0.1s; }
 
 /* ── Sidebar (TOC) ────────────────────────────────────────────────────────── */
 #sidebar {
@@ -102,8 +106,12 @@ body {
   border: none;
 }
 
+#sidebar::-webkit-scrollbar { width: 4px; }
+#sidebar::-webkit-scrollbar-track { background: transparent; }
+#sidebar::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 2px; }
+
 #sidebar h2 {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--ink-light);
@@ -119,16 +127,21 @@ body {
 
 #search {
   width: 100%;
-  padding: 0.3rem 0.5rem;
+  padding: 0.35rem 0.6rem;
   font-size: 0.78rem;
   font-family: var(--font-body);
   border: 1px solid var(--rule);
-  border-radius: 2px;
+  border-radius: 3px;
   background: var(--paper);
   color: var(--ink);
+  outline: none;
+  transition: border-color 0.1s, box-shadow 0.1s;
 }
 
-#search:focus { outline: 1px solid var(--ink); border-color: var(--ink); }
+#search:focus {
+  border-color: var(--link);
+  box-shadow: 0 0 0 2px rgba(26, 63, 111, 0.15);
+}
 
 #toc {
   list-style: none;
@@ -139,16 +152,28 @@ body {
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
-  padding: 0.18rem 0.5rem;
+  padding: 0.22rem 0.75rem 0.22rem 0.6rem;
   font-size: 0.82rem;
   line-height: 1.3;
   color: var(--link);
   text-decoration: none;
-  border-radius: 2px;
+  border-left: 2px solid transparent;
+  border-radius: 0 2px 2px 0;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
 }
 
-#toc li a:hover { background: rgba(0,0,0,0.04); color: var(--link-hover); }
-#toc li a.active { background: rgba(0,0,0,0.07); color: var(--ink); font-weight: bold; }
+#toc li a:hover {
+  background: rgba(0,0,0,0.04);
+  border-left-color: var(--rule);
+  color: var(--link-hover);
+}
+
+#toc li a.active {
+  background: transparent;
+  border-left-color: var(--link);
+  color: var(--ink);
+  font-weight: bold;
+}
 
 #toc .sec-num {
   color: var(--ink-light);
@@ -173,85 +198,86 @@ body {
   max-width: calc(var(--code-w) + 8rem);
 }
 
-/* Document header — minimal, like the PDF's title-page area */
+/* Document header */
 #doc-header {
   text-align: center;
-  margin-bottom: 3rem;
-  padding-bottom: 1rem;
+  margin-bottom: 3.5rem;
+  padding-bottom: 1.5rem;
   border-bottom: 1px solid var(--rule);
 }
 
 #doc-header .doc-title {
-  font-size: 1.5rem;
+  font-family: var(--font-prose);
+  font-size: 1.75rem;
   font-weight: bold;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 #doc-header .doc-subtitle {
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   color: var(--ink-light);
-  margin-top: 0.25rem;
-  font-style: italic;
+  margin-top: 0.4rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-style: normal;
 }
 
 /* ── Sections ─────────────────────────────────────────────────────────────── */
 .section {
   margin: 0;
-  padding: 0.65rem 0 0.65rem 0;
+  padding: 0.85rem 0 0.85rem 3rem;
   position: relative;
-  /* Section number floats in the left margin */
-  padding-left: 3rem;
   scroll-margin-top: 1rem;
 }
 
-/* The section-num is shown in the left margin (small, gray) */
 .section-num {
   position: absolute;
   left: 0;
-  top: 0.65rem;
+  top: 0.85rem;
   width: 2.5rem;
   text-align: right;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   color: var(--ink-light);
   font-variant-numeric: tabular-nums;
+  font-family: var(--font-prose);
+  opacity: 0.7;
   user-select: none;
 }
 
 .section-num a { color: inherit; text-decoration: none; }
-.section-num a:hover { color: var(--link-hover); }
+.section-num a:hover { color: var(--link-hover); opacity: 1; }
 
 /* Starred sections get a chapter-level break */
 .section.starred {
-  margin-top: 4rem;
-  padding-top: 2.5rem;
-  border-top: 1px solid var(--ink);
+  margin-top: 3.5rem;
+  padding-top: 2.75rem;
+  border-top: 2px solid var(--ink);
 }
 
-/* The first section never needs a top break */
 .section.starred:first-of-type {
   margin-top: 0;
 }
 
 .section-title {
-  font-size: 1.05rem;
+  font-family: var(--font-prose);
+  font-size: 1.08rem;
   font-weight: bold;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.4rem;
   letter-spacing: 0.01em;
 }
 
 .section-title .part-label {
   color: var(--ink-light);
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: normal;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   display: block;
-  margin-bottom: 0.15rem;
+  margin-bottom: 0.2rem;
+  font-family: var(--font-body);
 }
 
-/* The bold inline section number that opens prose paragraphs.
-   Mirrors the PDF's "1. Introduction." form when the section has a title,
-   or just "1." when it doesn't. */
 .section-marker {
   font-weight: bold;
   margin-right: 0.4em;
@@ -259,26 +285,33 @@ body {
 
 /* ── Prose ────────────────────────────────────────────────────────────────── */
 .tex-prose {
+  font-family: var(--font-prose);
+  font-size: 1.05rem;
+  line-height: 1.55;
   max-width: var(--text-w);
   text-align: justify;
   hyphens: auto;
   -webkit-hyphens: auto;
 }
 
-.tex-prose p { margin: 0 0 0.4em 0; text-indent: 0; }
-.tex-prose p + p { text-indent: 1.5em; margin-top: 0; } /* book-style indent on continuation paragraphs */
+.tex-prose p { margin: 0 0 0.5em 0; text-indent: 0; }
+.tex-prose p + p { text-indent: 1.5em; margin-top: 0; }
 
 .tex-prose code {
   font-family: var(--font-mono);
-  font-size: 0.9em;
+  font-size: 0.875em;
   letter-spacing: 0;
-  /* No background — the PDF doesn't tint inline code. */
 }
 
 .tex-prose strong { font-weight: bold; }
 .tex-prose em { font-style: italic; }
 
-.tex-prose em.slanted { font-style: normal; font-family: var(--font-body); font-variant-caps: normal; transform: skewX(-12deg); display: inline-block; }
+.tex-prose em.slanted {
+  font-style: normal;
+  font-family: var(--font-body);
+  transform: skewX(-12deg);
+  display: inline-block;
+}
 
 .item {
   display: flex;
@@ -298,7 +331,6 @@ body {
   letter-spacing: 0.04em;
 }
 
-/* TeX-family logos: emulate the lowered uppercase E */
 .tex-logo {
   font-family: var(--font-body);
   letter-spacing: 0;
@@ -310,9 +342,8 @@ body {
   margin: 0 -0.07em;
 }
 
-/* KaTeX display blocks */
 .katex-display {
-  margin: 0.6rem 0;
+  margin: 0.7rem 0;
   overflow-x: auto;
 }
 
@@ -345,16 +376,18 @@ body {
 
 /* ── Code blocks ──────────────────────────────────────────────────────────── */
 .code-block-wrap {
-  margin: 0.45rem 0 0.4rem 0;
+  margin: 0.5rem 0 0.45rem 0;
 }
 
 .chunk-label {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  margin-bottom: 0.2rem;
+  font-family: var(--font-prose);
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-light);
+  margin-bottom: 0.3rem;
 }
 
-.chunk-label a { color: var(--link); text-decoration: none; }
+.chunk-label a { color: var(--link); text-decoration: none; font-style: normal; }
 .chunk-label a:hover { text-decoration: underline; }
 
 pre.code-block {
@@ -362,10 +395,11 @@ pre.code-block {
   color: var(--ink);
   font-family: var(--font-mono);
   font-size: 0.88rem;
-  line-height: 1.4;
-  padding: 0.65rem 0.9rem;
+  line-height: 1.42;
+  padding: 0.75rem 1rem;
   border: 1px solid var(--rule);
-  border-radius: 2px;
+  border-left: 3px solid var(--rule);
+  border-radius: 0;
   overflow-x: auto;
   max-width: var(--code-w);
   tab-size: 4;
@@ -374,14 +408,13 @@ pre.code-block {
   word-break: break-word;
 }
 
-/* Override Prism's tomorrow theme to keep our paper-like aesthetic */
-pre.code-block .token.comment    { color: #777; font-style: italic; }
-pre.code-block .token.keyword    { color: #003366; font-weight: bold; }
-pre.code-block .token.string     { color: #663300; }
-pre.code-block .token.number     { color: #663300; }
-pre.code-block .token.operator   { color: #444; }
-pre.code-block .token.punctuation{ color: #444; }
-pre.code-block .token.function   { color: #1a4480; }
+pre.code-block .token.comment    { color: #7a7060; font-style: italic; }
+pre.code-block .token.keyword    { color: #2b3d6e; font-weight: bold; }
+pre.code-block .token.string     { color: #5c3000; }
+pre.code-block .token.number     { color: #5c3000; }
+pre.code-block .token.operator   { color: #5a5040; }
+pre.code-block .token.punctuation{ color: #5a5040; }
+pre.code-block .token.function   { color: var(--link); }
 
 .chunk-ref {
   color: var(--link);
@@ -391,23 +424,91 @@ pre.code-block .token.function   { color: #1a4480; }
 .chunk-ref:hover { text-decoration: underline; color: var(--link-hover); }
 .chunk-ref.unresolved { color: var(--ink-light); cursor: help; }
 
-/* ── Toggle button ────────────────────────────────────────────────────────── */
-#toggle-sidebar {
+/* ── Toggle buttons (sidebar + graph) ────────────────────────────────────── */
+#toggle-sidebar,
+#toggle-graph {
   position: fixed;
   top: 0.5rem;
-  left: 0.5rem;
   z-index: 100;
   background: var(--paper-soft);
   border: 1px solid var(--rule);
-  border-radius: 2px;
+  border-radius: 3px;
   cursor: pointer;
-  font-size: 1rem;
-  line-height: 1;
-  padding: 0.25rem 0.45rem;
+  font-size: 1.05rem;
+  line-height: 1.2;
+  padding: 0.3rem 0.55rem;
   color: var(--ink);
   font-family: var(--font-body);
+  transition: background 0.1s;
 }
-#toggle-sidebar:hover { background: var(--rule); }
+#toggle-sidebar { left: 0.5rem; }
+#toggle-graph   { left: 3rem; }
+
+#toggle-sidebar:hover,
+#toggle-graph:hover { background: var(--rule); }
+
+/* ── Graph overlay ────────────────────────────────────────────────────────── */
+#graph-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+}
+#graph-overlay[hidden] { display: none; }
+
+#graph-toolbar {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--rule);
+  font-size: 0.85rem;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+#graph-title {
+  flex: 1;
+  font-weight: bold;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-light);
+}
+
+#graph-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--ink-light);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+  transition: color 0.1s, background 0.1s;
+  font-family: var(--font-body);
+}
+#graph-close:hover { color: var(--ink); background: var(--rule); }
+
+#graph-svg {
+  flex: 1;
+  width: 100%;
+  display: block;
+  cursor: grab;
+}
+#graph-svg:active { cursor: grabbing; }
+
+#graph-legend {
+  padding: 0.4rem 1rem;
+  font-size: 0.75rem;
+  color: var(--ink-light);
+  border-top: 1px solid var(--rule);
+  display: flex;
+  gap: 1.5rem;
+  flex-shrink: 0;
+  font-family: var(--font-body);
+}
 
 /* ── Utility ──────────────────────────────────────────────────────────────── */
 .hfill { flex: 1; }
@@ -430,7 +531,8 @@ pre.code-block .token.function   { color: #1a4480; }
   padding: 0;
   column-width: 14rem;
   column-gap: 2rem;
-  font-size: 0.88rem;
+  font-family: var(--font-prose);
+  font-size: 0.9rem;
 }
 
 .index-list li {
@@ -457,22 +559,22 @@ pre.code-block .token.function   { color: #1a4480; }
   background: var(--ink);
   color: var(--paper);
   border: none;
-  border-radius: 4px;
+  border-radius: 3px;
   padding: 4px 10px;
   font-size: 0.75rem;
   font-family: var(--font-body);
   cursor: pointer;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
   display: none;
 }
 #report-btn:hover { background: var(--link); }
 
 /* ── Print ────────────────────────────────────────────────────────────────── */
 @media print {
-  #sidebar, #toggle-sidebar { display: none !important; }
+  #sidebar, #toggle-sidebar, #toggle-graph, #graph-overlay { display: none !important; }
   body { font-size: 10.5pt; }
   #main { padding: 0; max-width: 100%; }
-  pre.code-block { background: #f6f4ed; }
+  pre.code-block { background: #f0ece3; border-left-width: 1px; }
   a { color: inherit; text-decoration: none; }
   .section { break-inside: avoid; }
   .section.starred { break-before: page; }
@@ -481,7 +583,8 @@ pre.code-block .token.function   { color: #1a4480; }
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 760px) {
   #sidebar { display: none; }
+  #toggle-graph { left: 3rem; }
   #main { padding: 1.5rem 1rem 4rem; }
-  .section { padding-left: 0; }
-  .section-num { position: static; text-align: left; margin-bottom: 0.2rem; }
+  .section { padding-left: 0; padding-top: 0.6rem; padding-bottom: 0.6rem; }
+  .section-num { position: static; text-align: left; margin-bottom: 0.2rem; opacity: 1; }
 }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -109,6 +109,140 @@
     });
   }
 
+  // ── Graph view ──────────────────────────────────────────────────────────────
+  const graphOverlay = document.getElementById('graph-overlay');
+  const toggleGraphBtn = document.getElementById('toggle-graph');
+  const graphCloseBtn = document.getElementById('graph-close');
+  const graphSvgEl = document.getElementById('graph-svg');
+
+  let d3Loaded = false;
+
+  function loadD3() {
+    return new Promise((resolve) => {
+      if (d3Loaded) { resolve(); return; }
+      const s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js';
+      s.onload = () => { d3Loaded = true; resolve(); };
+      document.head.appendChild(s);
+    });
+  }
+
+  function renderGraph() {
+    const data = window.__GRAPH_DATA__;
+    if (!data || !graphSvgEl) return;
+
+    const width = graphSvgEl.clientWidth;
+    const height = graphSvgEl.clientHeight;
+
+    // Resolve CSS variable colours for use in D3 (which doesn't read CSS vars on SVG attrs)
+    const style = getComputedStyle(document.documentElement);
+    const colLink = style.getPropertyValue('--link').trim();
+    const colRule = style.getPropertyValue('--rule').trim();
+    const colInk  = style.getPropertyValue('--ink').trim();
+    const colPaper = style.getPropertyValue('--paper').trim();
+    const colInkLight = style.getPropertyValue('--ink-light').trim();
+
+    d3.select(graphSvgEl).selectAll('*').remove();
+
+    const svg = d3.select(graphSvgEl)
+      .call(d3.zoom().scaleExtent([0.05, 6]).on('zoom', (e) => {
+        g.attr('transform', e.transform);
+      }));
+
+    const g = svg.append('g');
+
+    svg.append('defs').append('marker')
+      .attr('id', 'arrowhead')
+      .attr('viewBox', '0 -3 6 6')
+      .attr('refX', 15).attr('refY', 0)
+      .attr('markerWidth', 5).attr('markerHeight', 5)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('d', 'M0,-3L6,0L0,3')
+      .attr('fill', colRule);
+
+    // Deep-clone nodes/edges so D3 can mutate them for simulation
+    const nodes = data.nodes.map(d => ({ ...d }));
+    const edges = data.edges.map(d => ({ ...d }));
+
+    const simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(edges).id(d => d.id).distance(55).strength(0.4))
+      .force('charge', d3.forceManyBody().strength(-100))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collision', d3.forceCollide(13));
+
+    const link = g.append('g')
+      .selectAll('line')
+      .data(edges)
+      .join('line')
+      .attr('stroke', colRule)
+      .attr('stroke-width', 1)
+      .attr('stroke-opacity', 0.7)
+      .attr('marker-end', 'url(#arrowhead)');
+
+    const nodeGroup = g.append('g')
+      .selectAll('g')
+      .data(nodes)
+      .join('g')
+      .attr('cursor', 'pointer')
+      .on('click', (e, d) => {
+        graphOverlay.hidden = true;
+        const target = document.getElementById(d.id);
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      })
+      .call(
+        d3.drag()
+          .on('start', (e, d) => {
+            if (!e.active) simulation.alphaTarget(0.3).restart();
+            d.fx = d.x; d.fy = d.y;
+          })
+          .on('drag', (e, d) => { d.fx = e.x; d.fy = e.y; })
+          .on('end', (e, d) => {
+            if (!e.active) simulation.alphaTarget(0);
+            d.fx = null; d.fy = null;
+          })
+      );
+
+    nodeGroup.append('circle')
+      .attr('r', d => d.starred ? 9 : 5)
+      .attr('fill', d => d.starred ? colLink : colPaper)
+      .attr('stroke', d => d.starred ? colLink : colRule)
+      .attr('stroke-width', d => d.starred ? 0 : 1.5);
+
+    // Chapter labels
+    nodeGroup.filter(d => d.starred).append('text')
+      .attr('dy', '0.35em')
+      .attr('x', 12)
+      .attr('font-size', '10px')
+      .attr('font-family', 'Inter, sans-serif')
+      .attr('fill', colInk)
+      .attr('pointer-events', 'none')
+      .text(d => d.title ? `§${d.num} ${d.title}` : `§${d.num}`);
+
+    // Tooltip for all nodes
+    nodeGroup.append('title')
+      .text(d => d.title ? `§${d.num}: ${d.title}` : `§${d.num}`);
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => d.source.x).attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+      nodeGroup.attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+  }
+
+  if (toggleGraphBtn && graphOverlay) {
+    toggleGraphBtn.addEventListener('click', async () => {
+      graphOverlay.hidden = false;
+      await loadD3();
+      renderGraph();
+    });
+    graphCloseBtn?.addEventListener('click', () => { graphOverlay.hidden = true; });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !graphOverlay.hidden) graphOverlay.hidden = true;
+    });
+  }
+
   // ── Reporting Mechanism ─────────────────────────────────────────────────────
   const reportBtn = document.createElement('button');
   reportBtn.id = 'report-btn';


### PR DESCRIPTION
…raph view

- Apply Computer Modern Serif to all prose text (was loaded but never used)
- Warm colour palette: #fdfaf4 paper, warm near-black ink, warmer rules/sidebar
- Add --font-prose CSS variable; sidebar/UI stays Inter
- Load JetBrains Mono from Google Fonts (was listed in font stack but not fetched)
- Sidebar: widen to 260px, left-border active indicator on TOC, thin scrollbar, better search focus ring with box-shadow
- Document header: uppercase CM title, uppercase tracking subtitle
- Section breaks: 2px border-top on starred sections, 0.85rem padding
- Code blocks: border-radius 0, 3px left accent border, 0.75rem/1rem padding
- Chunk labels: CM italic styling
- Link colour transitions (0.1s)
- Add force-directed graph view (D3.js, lazy-loaded from CDN):
  - ⬡ button opens full-screen overlay
  - Nodes for every WEB section; edges from chunk-reference relationships
  - Starred (chapter) sections: larger blue filled circles with title labels
  - Drag nodes, scroll to zoom, pan; click node navigates to section
  - Escape key dismisses; graph data embedded as JSON at build time
- Add buildGraphData() to src/build.js; embed window.__GRAPH_DATA__ in HTML
- Update HTML template with graph overlay markup and ⬡ toggle button

https://claude.ai/code/session_015NdPkYVsbVx21oWPcvsMSF