### PR TITLE
Fix mathematical symbol rendering and KaTeX errors

### DIFF
--- a/reports.json
+++ b/reports.json
@@ -1,5 +1,5 @@
 {
-  "processed": false,
+  "processed": true,
   "reports": [
     {
       "selection": "<>",

--- a/src/build.js
+++ b/src/build.js
@@ -27,12 +27,13 @@ function escapeHtml(s) {
  * chunk references into §N links.
  */
 function renderCode(raw, chunkDefs) {
-  if (!raw || !raw.trim()) return '';
+  const trimmedRaw = raw.trim();
+  if (!trimmedRaw) return '';
 
   // First, replace @<Name@> with placeholder tokens, then Prism-highlight,
   // then substitute the placeholders back as links.
   const refs = [];
-  let processed = raw.replace(/@<([^@]*)@>/g, (_, name) => {
+  let processed = trimmedRaw.replace(/@<([^@]*)@>/g, (_, name) => {
     const trimmed = name.trim();
     const defNums = chunkDefs.get(trimmed) || [];
     const target = defNums[0] ? `s${defNums[0]}` : null;
@@ -62,6 +63,14 @@ function renderCode(raw, chunkDefs) {
   } catch {
     highlighted = escapeHtml(processed);
   }
+
+  // Replace operators with mathematical symbols for that classic WEB look
+  highlighted = highlighted
+    .replace(/&lt;&gt;/g, '≠')
+    .replace(/&lt;>/g, '≠')
+    .replace(/&lt;=/g, '≤')
+    .replace(/&gt;=/g, '≥')
+    .replace(/>=/g, '≥');
 
   // Restore chunk refs
   highlighted = highlighted.replace(/\x00CHUNKREF(\d+)\x00/g, (_, i) => {

--- a/src/tex-to-html.js
+++ b/src/tex-to-html.js
@@ -41,7 +41,7 @@ function renderMath(math, display, placeholders) {
   try {
     return katex.renderToString(resolvedMath, {
       displayMode: display,
-      throwOnError: false,
+      throwOnError: true,
       macros: {
         "\\.": "\\texttt{#1}",
         "\\&": "\\textbf{#1}",
@@ -68,8 +68,9 @@ function renderMath(math, display, placeholders) {
         "\\O": "\\texttt{#1}",
       }
     });
-  } catch {
-    return `<code class="math-fallback">${escapeHtml(resolvedMath)}</code>`;
+  } catch (err) {
+    const cls = display ? 'math-fallback display' : 'math-fallback';
+    return `<code class="${cls}">${escapeHtml(resolvedMath)}</code>`;
   }
 }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -347,6 +347,26 @@ a { transition: color 0.1s; }
   overflow-x: auto;
 }
 
+.math-fallback {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--paper-soft);
+  padding: 0 0.3em;
+  border-radius: 3px;
+  color: var(--ink-light);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.math-fallback.display {
+  display: block;
+  padding: 1rem;
+  margin: 0.7rem 0;
+  border: 1px dashed var(--rule);
+  background: var(--paper-soft);
+}
+
 /* ── Macro definitions (@d / @f) ──────────────────────────────────────────── */
 .defs {
   margin: 0.4rem 0 0.5rem 0;


### PR DESCRIPTION
This PR improves the rendering of mathematical symbols in code blocks and handles KaTeX errors for complex TeX primitives.

Key changes:
- Replaces Pascal operators (<>, <=, >=) with mathematical symbols (≠, ≤, ≥).
- Trims code blocks to remove trailing newlines and unnecessary padding.
- Implements a styled fallback for KaTeX rendering errors (e.g., for \halign).
- Marks processed reports as completed.